### PR TITLE
chore: bump go directive to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-openapi/inflect
 
-go 1.24
+go 1.25.0


### PR DESCRIPTION
## Summary

- Update all `go.mod` (and `go.work` where applicable) to require `go 1.25.0`
- Run `go mod tidy` / `go work sync` to update checksums

## Test plan

- [ ] CI passes on all platforms (ubuntu, macos, windows) x (stable, oldstable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)